### PR TITLE
Create schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = (params) => {
       `
       if not exists (
           select 1
-          from \`${params.ga4.project}.${params.ga4.dataset}.schemata\`
+          from \`${params.ga4.project}.INFORMATION_SCHEMA.SCHEMATA\`
           where schema_name = '${params.config.schema}'
       )
       then

--- a/index.js
+++ b/index.js
@@ -25,11 +25,11 @@ module.exports = (params) => {
       `
       if not exists (
           select 1
-          from "${params.ga4.project}.${params.ga4.dataset}.schemata"
+          from \`${params.ga4.project}.${params.ga4.dataset}.schemata"\`
           where schema_name = '${params.config.schema}'
       )
       then
-          create schema "${params.ga4.project}.${params.ga4.dataset}.${params.config.schema}";
+          create schema \`${params.ga4.project}.${params.ga4.dataset}.${params.config.schema}\`;
       end if;
       `
     );

--- a/index.js
+++ b/index.js
@@ -20,6 +20,19 @@ module.exports = (params) => {
       },
       ...params
     };
+
+    operate("create_testing_schema").queries(ctx => 
+      `
+      if not exists (
+          select 1
+          from "${params.ga4.project}.${params.ga4.dataset}.schemata"
+          where schema_name = '${params.config.schema}'
+      )
+      then
+          create schema `${params.ga4.project}.${params.ga4.dataset}.${params.config.schema}`;
+      end if;
+      `
+      );
     
     const ga4_source = declare({
       database: params.ga4.project,
@@ -28,6 +41,7 @@ module.exports = (params) => {
     });
 
     let result = {
+      setup: setup(params),
       ga4_source: ga4_source,
       ecommerce_test: ecommerce_test(params.ga4.table,params.date_start,params.date_end,params.config),
       session_quality_test: session_quality_test(params.ga4.table,params.date_start, params.date_end, params.config),

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = (params) => {
       `
       if not exists (
           select 1
-          from \`${params.ga4.project}.${params.ga4.dataset}.schemata"\`
+          from \`${params.ga4.project}.${params.ga4.dataset}.schemata\`
           where schema_name = '${params.config.schema}'
       )
       then

--- a/index.js
+++ b/index.js
@@ -21,18 +21,18 @@ module.exports = (params) => {
       ...params
     };
 
-    operate("create_testing_schema").queries(ctx => 
-      `
-      if not exists (
-          select 1
-          from \`${params.ga4.project}.INFORMATION_SCHEMA.SCHEMATA\`
-          where schema_name = '${params.config.schema}'
-      )
-      then
-          create schema \`${params.ga4.project}.${params.config.schema}\`;
-      end if;
-      `
-    );
+    // operate("create_testing_schema").queries(ctx => 
+    //   `
+    //   if not exists (
+    //       select 1
+    //       from \`${params.ga4.project}.INFORMATION_SCHEMA.SCHEMATA\`
+    //       where schema_name = '${params.config.schema}'
+    //   )
+    //   then
+    //       create schema \`${params.ga4.project}.${params.config.schema}\`;
+    //   end if;
+    //   `
+    // );
     
     const ga4_source = declare({
       database: params.ga4.project,

--- a/index.js
+++ b/index.js
@@ -41,7 +41,6 @@ module.exports = (params) => {
     });
 
     let result = {
-      setup: setup(params),
       ga4_source: ga4_source,
       ecommerce_test: ecommerce_test(params.ga4.table,params.date_start,params.date_end,params.config),
       session_quality_test: session_quality_test(params.ga4.table,params.date_start, params.date_end, params.config),

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = (params) => {
           where schema_name = '${params.config.schema}'
       )
       then
-          create schema \`${params.ga4.project}.${params.ga4.dataset}.${params.config.schema}\`;
+          create schema \`${params.ga4.project}.${params.config.schema}\`;
       end if;
       `
     );

--- a/index.js
+++ b/index.js
@@ -29,10 +29,10 @@ module.exports = (params) => {
           where schema_name = '${params.config.schema}'
       )
       then
-          create schema `${params.ga4.project}.${params.ga4.dataset}.${params.config.schema}`;
+          create schema "${params.ga4.project}.${params.ga4.dataset}.${params.config.schema}";
       end if;
       `
-      );
+    );
     
     const ga4_source = declare({
       database: params.ga4.project,


### PR DESCRIPTION
This should make the package a bit more plug-and-play. The view creation commands could explicitly declare their dependence on the `create_testing_schema` but this will work regardless.